### PR TITLE
Remove comments from tilejson files

### DIFF
--- a/layers/epsg3857/landsat.tilejson
+++ b/layers/epsg3857/landsat.tilejson
@@ -4,17 +4,10 @@
   "description": "",
   "version": "1.0.0",
   "attribution": "<a href='http://www.gina.alaska.edu'>Geographic Information Network of Alaska</a>",
-//  "template": "",
-//  "legend": "",
   "scheme": "xyz",
   "tiles": [
     "http://tiles.gina.alaska.edu/tilesrv/landsat_pan/tile/{x}/{y}/{z}.png"
   ],
-//  "grids": [
-//    
-//  ],
-// "data": [
-//  ],
   "minzoom": 0,
   "maxzoom": 18,
   "center": [64.86, -147.849],

--- a/layers/epsg3857/noaa_charts.tilejson
+++ b/layers/epsg3857/noaa_charts.tilejson
@@ -4,19 +4,11 @@
   "description": "Not for navigation!",
   "version": "1.0.0",
   "attribution": "<a href='http://www.gina.alaska.edu'>Geographic Information Network of Alaska</a>",
-//  "template": "",
-//  "legend": "",
   "scheme": "xyz",
   "tiles": [
     "http://tiles.gina.alaska.edu/tilesrv/charts/tile/{x}/{y}/{z}.png"
   ],
-//  "grids": [
-//    
-//  ],
-// "data": [
-//  ],
   "minzoom": 0,
   "maxzoom": 18,
-//  "center": [],
   "bounds": [-180, -90, 180, 90]
 }

--- a/layers/epsg3857/ortho_rgb.tilejson
+++ b/layers/epsg3857/ortho_rgb.tilejson
@@ -4,19 +4,11 @@
   "description": "",
   "version": "1.0.0",
   "attribution": "<a href='http://www.gina.alaska.edu'>Geographic Information Network of Alaska</a>",
-//  "template": "",
-//  "legend": "",
   "scheme": "xyz",
   "tiles": [
     "http://tiles.gina.alaska.edu/tiles/SPOT5.SDMI.ORTHO_RGB/tile/{x}/{y}/{z}.png"
   ],
-//  "grids": [
-//    
-//  ],
-// "data": [
-//  ],
   "minzoom": 0,
   "maxzoom": 18,
-//  "center": [],
   "bounds": [-180, -90, 180, 90]
 }

--- a/layers/epsg3857/osm.tilejson
+++ b/layers/epsg3857/osm.tilejson
@@ -4,19 +4,11 @@
   "description": "",
   "version": "1.0.0",
   "attribution": "<a href='http://openstreetmap.org'>OSM contributors</a>",
-//  "template": "",
-//  "legend": "",
   "scheme": "xyz",
   "tiles": [
     "http://tiles.gina.alaska.edu/tilesrv/osm/tile/{x}/{y}/{z}.png"
   ],
-//  "grids": [
-//    
-//  ],
-// "data": [
-//  ],
   "minzoom": 0,
   "maxzoom": 18,
-//  "center": [],
   "bounds": [-180, -90, 180, 90]
 }

--- a/layers/epsg3857/shaded_relief.tilejson
+++ b/layers/epsg3857/shaded_relief.tilejson
@@ -4,19 +4,11 @@
   "description": "",
   "version": "1.0.0",
   "attribution": "<a href='http://www.gina.alaska.edu'>Geographic Information Network of Alaska</a>",
-//  "template": "",
-//  "legend": "",
   "scheme": "xyz",
   "tiles": [
     "http://tiles.gina.alaska.edu/tilesrv/shaded_relief_ned/tile/{x}/{y}/{z}.png"
   ],
-//  "grids": [
-//    
-//  ],
-// "data": [
-//  ],
   "minzoom": 0,
   "maxzoom": 18,
-//  "center": [],
   "bounds": [-180, -90, 180, 90]
 }

--- a/layers/epsg3857/topo.tilejson
+++ b/layers/epsg3857/topo.tilejson
@@ -4,17 +4,10 @@
   "description": "",
   "version": "1.0.0",
   "attribution": "<a href='http://www.gina.alaska.edu'>Geographic Information Network of Alaska</a>",
-//  "template": "",
-//  "legend": "",
   "scheme": "xyz",
   "tiles": [
     "http://tiles.gina.alaska.edu/tilesrv/drg/tile/{x}/{y}/{z}"
   ],
-//  "grids": [
-//    
-//  ],
-// "data": [
-//  ],
   "minzoom": 0,
   "maxzoom": 18,
   "center": [64.86, -147.849],


### PR DESCRIPTION
Because some JSON parsers fail on comments, and they’re not meaningful comments.